### PR TITLE
French translation

### DIFF
--- a/_data/french.yml
+++ b/_data/french.yml
@@ -44,12 +44,12 @@ righttolink:
     please: "Je vous demande de prendre position contre un <strong>droit voisin supplémentaire pour les éditeurs de presse</strong> qui limiterait la possibilité de créer des liens vers les articles de presse."
     do: Rejetez l'amendement <abbr class="am" title="Calls for the introduction of an ancillary copyright for press publishers">#204</abbr>. Prenez position en faveur du compromis de l'amendement au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#licenses" target="_blank" class="am">#21</a> du rapport de la députée Julia Reda.
 publicdomain: 
-    h: "<span>Safeguard</span> the public domain"
-    cw: "Old artwork whose copyright has expired belongs to everyone. Yet some people claim digitising it grants new copyright."
-    eu: "Digitisation of works that are commonly owned shouldn't grant new protection."
+    h: "<span>Protéger</span> le domaine public"
+    cw: "Les œuvres anciennes dont le droit d'auteur a expiré appartiennent à tout le monde. Cependant, certains prétendent que le fait de les digitaliser leur accorde un nouveau droit d'auteur."
+    eu: "La digitalisation d'œuvres appartenant à tout le monde ne doit pas accorder de nouvelles protections."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#publicdomain"
-    please: "Please <strong>safeguard the public domain</strong> by clarifying that making a digital copy of something that's free of copyright doesn't grant new copyright."
-    do: Reject amendments that would water down point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#publicdomain" target="_blank" class="am">#6</a> in MEP Reda's report – support amendment <span class="am">#264</span> which clarifies it.
+    please: "Je vous demande de <strong>protéger le domaine public</strong> en clarifiant le fait que la digitalisation d'une œuvre libre de droits ne permet pas d'en obtenir de nouveaux."
+    do: Rejetez les amendements qui diluent le point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#publicdomain" target="_blank" class="am">#6</a> du rapport de la députée Julia Reda – prenez position en faveur de l'amendement <span class="am">#264</span> qui le clarifie.
 libraries: 
     h: "<span>Enable</span> libraries to do their job online"
     cw: "Libraries pay authors in return for the right to lend physical copies of books. But this right doesn't exist on the internet."

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -94,7 +94,7 @@ filesharing:
     do: Votez pour les amendements <abbr class="am" title="Calls for exploring the legalization of non commercial private sharing">#507</abbr> et <abbr class="am" title="Urges increased legal certainty for P2P sharing">#355</abbr>.
     tip: "Donnez un exemple de situation où le partage a été bénéfique à un artiste, par exemple vous avez découvert un artiste êtes devenu fan, ce qui vous a amené à assister à un concert ou acheter des produits dérivés."
 currentcopywrong: "Copywrong actuel :"  # TODO: Comment traduire 'copywrong' ? Est-ce qu'il faut traduire ?
-euproposal: "Proposition de l'EU:"      # TODO: Est-ce que c'est 'de' ou 'pour' ?
+euproposal: "Proposition de l'UE:"      # TODO: Est-ce que c'est 'de' ou 'pour' ?
 iwant: "C'est ce que je veux !"         # Maybe a bit too long... if modified, change also 'showmore'
 readmore: "Plus d'informations"
 joinfight: Si <span>tu</span> ne rejoins la lutte maintenant, ces "copywrongs" <u>ne seront pas corrigés</u>.

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -108,5 +108,5 @@ call:
 showmore: Pour afficher plus de points ici, faites défiler la page vers le haut et cliquer sur "je la veux"
 tell: Partagez
 icalled: J'ai appelé mon député pour sauver la réforme du droit d'auteur<br />– et toi?
-sharetext:  La réforme urgente du droit d'auteur est en danger. J'ai appelé mon député, et tu devrais aussi!
+sharetext: La réforme urgente du droit d'auteur en danger: Appel ton député, moi c'est déjà fait!
 credits: Créé par le bureau de la <a href="https://juliareda.eu" target="_blank">députée Julia Reda</a>, l'équipe de <a href="http://copy-me.org/" target="_blank">Copy-Me</a> et d'autes volontaires. <a href="https://github.com/Copywrongs-Gang/Copywrongs2">Fork me on Github</a><br />Charte graphique basée en partie sur des icônes créées par EliRatus, useiconic.com, Cornelius Danger, Pedro Vidal, John Caserta, Carolina Andrea, Magicon, Luis Prado – all licensed Creative Commons – Attribution (CC BY 3.0)

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -65,12 +65,12 @@ publicspace:
     please: "Je vous demande de soutenir une <strong>liberté de panorama</strong> dans toute l'Europe, afin que partager des photographies de bâtiments publics soit légal – que ce soit pour un usage commercial ou non."
     do: Rejetez tout amendement qui diluerait le point <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#panorama" target="_blank">#16</a> du rapport de la députée Julia Reda, votez en faveur du texte original ou d'un éventuel amendement de compromis.
 education: 
-    h: "<span>Protect</span> educational uses"
-    cw: "Schools may often freely use physical books to teach from – but putting the same content on the school intranet as a PDF can be illegal."
-    eu: "A Europe-wide comphrehensive copyright <strong>exception for educational use</strong>"
+    h: "<span>Protéger</span> les usages éducatifs"
+    cw: "Les professeurs utilisent souvent librement des livres physiques pour enseigner – mais mettre le même contenu en PDF à disposition des élèves sur l'intranet de l'école peut être illégal."
+    eu: "Une exception compréhensive et pan-européenne au droit d'auteur <strong>pour les usages éducatifs</strong>."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#education"
-    please: "Please support a copyright exception that allows <strong>educational use</strong> of copyrighted materials, also in the digital world."
-    do: Reject amendments that would water down point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#education" target="_blank" class="am">#19</a> in MEP Reda's report – that is, all except amendments <span class="am">#466-468</span>.
+    please: "Je vous demande de soutenir une exception au droit d'auteur qui permette les <strong>usages éducatifs</strong> d'œuvres protégées par le droit d'auteur, y-compris dans le monde digital."
+    do: Rejetez les amendements qui dilueraient le point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#education" target="_blank" class="am">#19</a> du rapport de la députée Julia Reda – c'est-à-dire tous les amendements exceptés les <span class="am">#466-468</span>.
 availability: 
     h: "<span>Enhance</span> the availability of works"
     cw: "Copyright lasts 70 years after the author's death. The vast majority of works are not profitable that long – they simply become unavailable."

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -72,12 +72,12 @@ education:
     please: "Je vous demande de soutenir une exception au droit d'auteur qui permette les <strong>usages éducatifs</strong> d'œuvres protégées par le droit d'auteur, y-compris dans le monde digital."
     do: Rejetez les amendements qui dilueraient le point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#education" target="_blank" class="am">#19</a> du rapport de la députée Julia Reda – c'est-à-dire tous les amendements exceptés les <span class="am">#466-468</span>.
 availability: 
-    h: "<span>Enhance</span> the availability of works"
-    cw: "Copyright lasts 70 years after the author's death. The vast majority of works are not profitable that long – they simply become unavailable."
-    eu: "Reduce the copyright term to the international standard of life + <strong>50 years</strong>."
+    h: "<span>Améliorer</span> la disponibilité des œuvres"
+    cw: "Le droit d'auteur dure 70 ans après la mort de l'auteur. La grande majorité des œuvres n'est pas rentable aussi longtemps – elles deviennent simplement introuvables."
+    eu: "Réduisez la durée de protection du droit d'auteur au standard international: vie de l'auteur + <strong>50 ans</strong>."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#term"
-    please: "Please support a harmonisation of <strong>copyright terms</strong> at the Berne Convention standard of life + <strong>50</strong> years."
-    do: Reject the amendments to point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#terms" target="_blank" class="am">#7</a> of MEP Reda's report and support point <span class="am">#18</span> from the <abbr title="Industry Committee">ITRE</abbr> opinion.
+    please: "Je vous demande de soutenir une harmonisation de la <strong>durée de protection accordée par le droit d'auteur</strong> au standard défini par la convention de Berne : vie + <strong>50 ans</strong>."
+    do: Rejetez les amendements au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#terms" target="_blank" class="am">#7</a> du rapport de la députée Julia Reda et supportez le point <span class="am">#18</span> de l'avis de l'<abbr title="Comission industrie, recherche et énergie">ITRE</abbr>.
 digitallocks: 
     h: "<span>Reject</span> digital locks"
     cw: "The law says you can make copies of media you purchased for private use – but in practice, digital locks often prevent you."

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -87,12 +87,12 @@ digitallocks:
     do: Votez pour le point <span class="am">#26</span> de l'avis de l'<abbr title="Commission marché intérieur et protection des consommateurs">IMCO</abbr> et le point <span class="am">#29</span> de l'avis de l'<abbr title="Commission industrie, recherche et énergie">ITRE</abbr>. Je vous demande de soutenir le compromis au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#drm" target="_blank" class="am">#23</a> du rapport de la députée Julia Reda et de rejeter tous les amendements au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#drm" target="_blank" class="am">#24</a> de ce même rapport.
     tip: "Donnez un exemple d'une situation où un DRM vous a empêché d'effectuer une action que la loi vous autorise à faire (par exemple effectuer une copie pour un usage privé)."
 filesharing: 
-    h: "<span>Legalise</span> personal file sharing"
-    cw: "Teenagers exchanging music online are made criminals by current laws. But frequently, a shared file is not a lost sale, but free advertising."
-    eu: "Recognise a right to share non-commercially."
-    please: "Please stop the criminalisation of personal, not-for-profit <strong>file sharing</strong>."
-    do: Vote for amendments <abbr class="am" title="Calls for exploring the legalization of non commercial private sharing">#507</abbr> and <abbr class="am" title="Urges increased legal certainty for P2P sharing">#355</abbr>.
-    tip: "Give an example of when file sharing was benefitial to an artist, e.g. you discovered an artist you became a fan of, attending concerts or buying their products later."
+    h: "<span>Légaliser</span> le partage non-marchand."
+    cw: "Les jeunes qui partagent de la musique sur Internet sont criminalisés par les lois existantes. Mais souvent, un morceau de musique partagé correspond à de la publicité gratuite, pas à une vente perdue."
+    eu: "Reconnaître un droit au partage non-marchand."
+    please: "Je vous demande d'arrêter la criminalisation du <strong>partage</strong> privé, à but non lucratif."
+    do: Votez pour les amendements <abbr class="am" title="Calls for exploring the legalization of non commercial private sharing">#507</abbr> et <abbr class="am" title="Urges increased legal certainty for P2P sharing">#355</abbr>.
+    tip: "Donner un exemple de situation où le partage a été bénéfique à un artiste, par exemple vous avez découvert un artiste êtes devenu fan, ce qui vous a amené à assister à un concert ou acheter des produits dérivés."
 currentcopywrong: "Current copywrong:"
 euproposal: "EU proposal:"
 iwant: "I want this!"

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -1,0 +1,112 @@
+title: Sauvez la réforme du droit d'auteur
+description: "Actuellement, l'UE est en train de débattre de propositions pour corriger des problèmes du droit d'auteur auxquels vous êtes confrontés tous les jours. Mais une puissante alliance tente de saboter ces réformes nécessaires. Allez-vous vous joindre à notre combat pour les sauver ?"
+callnow: "<span>Appelez maintenant</span> pour sauver ces réformes &ndash; ça ne prend que deux minutes !"
+savecreform: "Sauvez la<br />&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; réforme du</div>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;droit d'auteur"
+daysuntil: "jours jusqu'au vote"
+rightnow: "Actuellement,"
+debatingplans: "l'UE est en train de débattre de propositions pour corriger des problèmes du droit d'auteur auxquels vous êtes confrontés tous les jours."
+but: "Mais une puissante alliance tente de saboter ces réformes nécessaires."
+whichthree: "Quelles sont les 3 réformes les plus importantes à vos yeux ?"
+geoblocking: 
+    h: "<span>Surmonter</span> le blocage par géolocalisation"
+    cw: "Cette vidéo n'est pas disponible dans votre pays."
+    eu: "<strong>Interdiction</strong> des contrats qui imposent un blocage basé sur la position géographique des utilisateurs aux services d'hébergement de vidéos : il s'agit d'une forme de discrimination des utilisateurs."
+    please: "Je vous demande de prendre position contre <strong>tout type de blocage basé sur la position géographique</strong>, indépendamment du fait que le contenu bloqué soit vendu directement ou financé au moyen de publicités ou de fonds publics."
+    do: Votez pour l'amendement <abbr class="am" title="Calls for an end to geoblocking">#412</abbr> et <abbr class="am" title="States that geoblocking should not prevent cultural minorities from accessing content">#322</abbr> et le point <span class="am">#16</span> de l'avis de l'<abbr title="Marché intérieur et protection des consommateurs (Internal Market Committee)">IMCO</abbr>.
+    tip: "Donnez un exemple de situation où le blocage par géolocalisation vous affecte."
+extendborders: 
+    h: "<span>Étendre</span> vos droits au-delà des frontières"
+    cw: "Ce qui est autorisé varie beaucoup entre les différents pays de l'UE. Si vous ne vous renseignez pas sur les lois locales lorsque vous voyagez, vous pouvez devenir un criminel !"
+    eu: "Rendez les <strong>exceptions et limitations</strong> au droit d'auteur <strong>obligatoire</strong> à travers tous les pays membres de l'UE."
+    link: "https://juliareda.eu/copyright-evaluation-report-explained/#mandatory"
+    please: "Je vous demande de prendre position en faveur de <strong>l'harmonisation des exceptions et limitations</strong> et de leur application <strong>obligatoire</strong> pour tous les pays de l'UE, afin que mes droits ne changent pas à chaque frontière."
+    do: Rejetez les amendements au point <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#terms" target="_blank">#11</a> du rapport de la députée Julia Reda. Soutenez les ajouts <abbr class="am" title="Calls for new mandatory exceptions, for example for user-generated content">#353</abbr>, <abbr class="am" title="Calls for making exceptions mandatory">#366</abbr> et le point <span class="am">#15</span> de l'avis de l'<abbr title="Marché intérieur et protection des consommateurs (Internal Market Committee)">IMCO</abbr>.
+protectauthors: 
+    h: "<span>Protéger</span> les auteurs contre les contrats injustes"
+    cw: "Les artistes n'ont pas d'avocats. Les éditeurs et les labels en ont des légions. Devinez qui a le plus de poids lors de la négociation des contrats ?"
+    eu: "Protégez les artistes dans toute l'Europe contre leur exploitation par des <strong>contrats abusifs</strong> et permettez-leur de reprendre leur droits s'ils sont laissés à l'abandon."
+    link: "https://juliareda.eu/copyright-evaluation-report-explained/#authors"
+    please: "Je vous demande de prendre position pour <strong>protéger les artistes contre leur exploitation</strong> et contre l'utilisation de contrats abusifs."
+    do: Votez pour l'amendement de compromis sur le point <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#authors" target="_blank">#3</a> du rapport de la députée Julia Reda et soutenez les ajouts des amendements <abbr class="am" title="Cites a UN report that emphasizes the importance of protecting authors">#107</abbr>, <abbr class="am" title="Calls for an author's right to bring their works to the market themselves in case a rightholder does not do so for a period of time">#200</abbr> et <abbr class="am" title="Calls for income tied to exceptions and limitations (e.g. private copying levies) to go directly to the authors, not other rightholders">#527</abbr>.
+righttoquote: 
+    h: "<span>Grant</span> vloggers the right to quote"
+    cw: "Quoting some words is usually legal, but this hasn't been extended to videos or sound recordings – making YouTubers & podcasters outlaws."
+    eu: "Exceptions like the one for quotation must apply to all forms of cultural expression in a <strong>technology-neutral</strong> manner."
+    link: "https://juliareda.eu/copyright-evaluation-report-explained/#audiovisual"
+    please: "Please support <strong>extending quotation rights to audiovisual media</strong>."
+    do: Reject the amendments to point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#audiovisual" target="_blank" class="am">#14</a> of MEP Reda's report.
+    tip: "Give an example of when you've quoted something in video or audio or if you're a fan of creators who do."
+righttolink: 
+    h: "<span>Defend</span> your right to link"
+    cw: "The web is made of links. Can posting one be a crime? News publishers are calling for laws that limit how others can link to their websites."
+    eu: "Reject such laws and preserve the freedom to link."
+    link: "https://savethelink.org"
+    please: "Please take a stand against an <strong>ancillary copyright for press publishers</strong> which would restrict linking to news articles."
+    do: Reject amendment <abbr class="am" title="Calls for the introduction of an ancillary copyright for press publishers">#204</abbr>. Support the compromise amendment on point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#licenses" target="_blank" class="am">#21</a> of MEP Reda's report.
+publicdomain: 
+    h: "<span>Safeguard</span> the public domain"
+    cw: "Old artwork whose copyright has expired belongs to everyone. Yet some people claim digitising it grants new copyright."
+    eu: "Digitisation of works that are commonly owned shouldn't grant new protection."
+    link: "https://juliareda.eu/copyright-evaluation-report-explained/#publicdomain"
+    please: "Please <strong>safeguard the public domain</strong> by clarifying that making a digital copy of something that's free of copyright doesn't grant new copyright."
+    do: Reject amendments that would water down point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#publicdomain" target="_blank" class="am">#6</a> in MEP Reda's report – support amendment <span class="am">#264</span> which clarifies it.
+libraries: 
+    h: "<span>Enable</span> libraries to do their job online"
+    cw: "Libraries pay authors in return for the right to lend physical copies of books. But this right doesn't exist on the internet."
+    eu: "Allow <strong>e-lending</strong> so that libraries can continue fulfilling their important social function."
+    link: "https://juliareda.eu/copyright-evaluation-report-explained/#elending"
+    please: "Please allow libraries to <strong>e-lend books</strong>."
+    do: Vote for  amendments <abbr class="am" title="Calls for expanding mandatory exceptions to cover libraries">#348</abbr>, <abbr class="am" title="Calls for strengthening exceptions in the public interest">#350</abbr> and for points <span class="am">#16</span> and <span class="am">#22</span> from the <abbr title="Industry Committee">ITRE</abbr> opinion.
+publicspace: 
+    h: "<span>Ensure</span> public space is for everyone"
+    cw: "In Germany you can freely post photos of public buildings online – but across the border in France the architect could sue you!"
+    eu: "Ensure <strong>freedom of panorama</strong> across Europe: Publishing pictures of what's permanently in the public must be legal."
+    link: "https://juliareda.eu/copyright-evaluation-report-explained/#panorama"
+    please: "Please ensure <strong>freedom of panorama</strong> in Europe, so that sharing photos of public buildings is legal – no matter whether for commercial or non-commercial purposes."
+    do: Reject any amendements that water down <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#panorama" target="_blank">#16</a> of MEP Reda's report, vote for the original text or the compromise amendment if there is one.
+education: 
+    h: "<span>Protect</span> educational uses"
+    cw: "Schools may often freely use physical books to teach from – but putting the same content on the school intranet as a PDF can be illegal."
+    eu: "A Europe-wide comphrehensive copyright <strong>exception for educational use</strong>"
+    link: "https://juliareda.eu/copyright-evaluation-report-explained/#education"
+    please: "Please support a copyright exception that allows <strong>educational use</strong> of copyrighted materials, also in the digital world."
+    do: Reject amendments that would water down point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#education" target="_blank" class="am">#19</a> in MEP Reda's report – that is, all except amendments <span class="am">#466-468</span>.
+availability: 
+    h: "<span>Enhance</span> the availability of works"
+    cw: "Copyright lasts 70 years after the author's death. The vast majority of works are not profitable that long – they simply become unavailable."
+    eu: "Reduce the copyright term to the international standard of life + <strong>50 years</strong>."
+    link: "https://juliareda.eu/copyright-evaluation-report-explained/#term"
+    please: "Please support a harmonisation of <strong>copyright terms</strong> at the Berne Convention standard of life + <strong>50</strong> years."
+    do: Reject the amendments to point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#terms" target="_blank" class="am">#7</a> of MEP Reda's report and support point <span class="am">#18</span> from the <abbr title="Industry Committee">ITRE</abbr> opinion.
+digitallocks: 
+    h: "<span>Reject</span> digital locks"
+    cw: "The law says you can make copies of media you purchased for private use – but in practice, digital locks often prevent you."
+    eu: "Ensure that technical measures can't limit your legal rights."
+    link: "https://juliareda.eu/copyright-evaluation-report-explained/#drm"
+    please: "Please ensure that technological protection (<strong>DRM</strong>) does not obstruct legal use of purchased content."
+    do: Vote for point <span class="am">#26</span> from the <abbr title="Internal Market Committee">IMCO</abbr> opinion and point <span class="am">#29</span> from the <abbr title="Industry Committee">ITRE</abbr> opinion. Support the compromise on point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#drm" target="_blank" class="am">#23</a> of MEP Reda's report and reject all amendments to point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#drm" target="_blank" class="am">#24</a>.
+    tip: "Give an example of when DRM stood in the way of your legal activity (eg. making copies for private use)."
+filesharing: 
+    h: "<span>Legalise</span> personal file sharing"
+    cw: "Teenagers exchanging music online are made criminals by current laws. But frequently, a shared file is not a lost sale, but free advertising."
+    eu: "Recognise a right to share non-commercially."
+    please: "Please stop the criminalisation of personal, not-for-profit <strong>file sharing</strong>."
+    do: Vote for amendments <abbr class="am" title="Calls for exploring the legalization of non commercial private sharing">#507</abbr> and <abbr class="am" title="Urges increased legal certainty for P2P sharing">#355</abbr>.
+    tip: "Give an example of when file sharing was benefitial to an artist, e.g. you discovered an artist you became a fan of, attending concerts or buying their products later."
+currentcopywrong: "Current copywrong:"
+euproposal: "EU proposal:"
+iwant: "I want this!"
+readmore: "Read more"
+joinfight: If <span>you</span> don't join the fight now, these "copywrongs" <u>won't be fixed</u>.
+call:
+    h: "Call now to fix copyright"
+    text: "The job of Members of the European Parliament is to <strong>represent you</strong>. We hate cold-calling people as much as you do &ndash; but if you don't take <strong>2 minutes</strong> to tell them what you care about, <strong>only lobbyists will be heard</strong>. You can do it, and <u>every call really makes a difference!</u>"
+    showother: "Show me another MEP"
+    what: "What will the call be like?"
+    agenda: "Your personal agenda:"
+    agendatext: "Regarding the <strong>copyright report</strong> that you will vote on in the Legal Affairs Committee on June 16th..."
+showmore: To show more points here, scroll up and click "I want this"
+tell: Tell the world
+icalled: I called my MEP to save copyright reform<br />– will you, too?
+sharetext:  Urgently needed copyright reform plans are in danger. I called my MEP and you should, too!
+credits: Created by the office of <a href="https://juliareda.eu" target="_blank">MEP Julia Reda</a>, the team of <a href="http://copy-me.org/" target="_blank">Copy-Me</a> and additional volunteers. <a href="https://github.com/Copywrongs-Gang/Copywrongs2">Fork me on Github</a><br />Graphics based in part on icons by EliRatus, useiconic.com, Cornelius Danger, Pedro Vidal, John Caserta, Carolina Andrea, Magicon, Luis Prado – all licensed Creative Commons – Attribution (CC BY 3.0)

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -12,7 +12,7 @@ geoblocking:
     cw: "Cette vidéo n'est pas disponible dans votre pays."
     eu: "<strong>Interdiction</strong> des contrats qui imposent un blocage basé sur la position géographique des utilisateurs aux services d'hébergement de vidéos : il s'agit d'une forme de discrimination des utilisateurs."
     please: "Je vous demande de prendre position contre <strong>tout type de blocage basé sur la position géographique</strong>, indépendamment du fait que le contenu bloqué soit vendu directement ou financé au moyen de publicités ou de fonds publics."
-    do: Votez pour l'amendement <abbr class="am" title="Calls for an end to geoblocking">#412</abbr> et <abbr class="am" title="States that geoblocking should not prevent cultural minorities from accessing content">#322</abbr> et le point <span class="am">#16</span> de l'avis de l'<abbr title="Marché intérieur et protection des consommateurs (Internal Market Committee)">IMCO</abbr>.
+    do: Votez pour l'amendement <abbr class="am" title="Calls for an end to geoblocking">#412</abbr> et <abbr class="am" title="States that geoblocking should not prevent cultural minorities from accessing content">#322</abbr> et le point <span class="am">#16</span> de l'avis de l'<abbr title="Commission marché intérieur et protection des consommateurs">IMCO</abbr>.
     tip: "Donnez un exemple de situation où le blocage par géolocalisation vous affecte."
 extendborders: 
     h: "<span>Étendre</span> vos droits au-delà des frontières"
@@ -51,12 +51,12 @@ publicdomain:
     please: "Je vous demande de <strong>protéger le domaine public</strong> en clarifiant le fait que la digitalisation d'une œuvre libre de droits ne permet pas d'en obtenir de nouveaux."
     do: Rejetez les amendements qui diluent le point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#publicdomain" target="_blank" class="am">#6</a> du rapport de la députée Julia Reda – prenez position en faveur de l'amendement <span class="am">#264</span> qui le clarifie.
 libraries: 
-    h: "<span>Enable</span> libraries to do their job online"
-    cw: "Libraries pay authors in return for the right to lend physical copies of books. But this right doesn't exist on the internet."
-    eu: "Allow <strong>e-lending</strong> so that libraries can continue fulfilling their important social function."
+    h: "<span>Permettre</span> aux librairies de faire leur travail en ligne"
+    cw: "Les librairies paient les auteurs en compensation du droit de prêter des copies physiques de leurs livres. Mais ce droit n'existe sur Internet."
+    eu: "Permettez le <strong>prêt électronique</strong> afin que les librairies puissent remplir leur mission sociale."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#elending"
-    please: "Please allow libraries to <strong>e-lend books</strong>."
-    do: Vote for  amendments <abbr class="am" title="Calls for expanding mandatory exceptions to cover libraries">#348</abbr>, <abbr class="am" title="Calls for strengthening exceptions in the public interest">#350</abbr> and for points <span class="am">#16</span> and <span class="am">#22</span> from the <abbr title="Industry Committee">ITRE</abbr> opinion.
+    please: "Je vous demande de prendre position en faveur de l'autorisation du <strong>prêt de livres électroniques</strong> pour les librairies."
+    do: Votez pour les amendements <abbr class="am" title="Calls for expanding mandatory exceptions to cover libraries">#348</abbr>, <abbr class="am" title="Calls for strengthening exceptions in the public interest">#350</abbr> et pour les points <span class="am">#16</span> et <span class="am">#22</span> de l'avis de l'<abbr title="Commission intustrie, recherche et énergie">ITRE</abbr>.
 publicspace: 
     h: "<span>Ensure</span> public space is for everyone"
     cw: "In Germany you can freely post photos of public buildings online – but across the border in France the architect could sue you!"

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -58,12 +58,12 @@ libraries:
     please: "Je vous demande de prendre position en faveur de l'autorisation du <strong>prêt de livres électroniques</strong> pour les librairies."
     do: Votez pour les amendements <abbr class="am" title="Calls for expanding mandatory exceptions to cover libraries">#348</abbr>, <abbr class="am" title="Calls for strengthening exceptions in the public interest">#350</abbr> et pour les points <span class="am">#16</span> et <span class="am">#22</span> de l'avis de l'<abbr title="Commission intustrie, recherche et énergie">ITRE</abbr>.
 publicspace: 
-    h: "<span>Ensure</span> public space is for everyone"
-    cw: "In Germany you can freely post photos of public buildings online – but across the border in France the architect could sue you!"
-    eu: "Ensure <strong>freedom of panorama</strong> across Europe: Publishing pictures of what's permanently in the public must be legal."
+    h: "<span>S'assurer</span> que l'espace public soit public"
+    cw: "En Allemagne, vous pouvez publier librement sur Internet des photographies de bâtiments – mais de l'autre côté de la frontière, en France, les architectes peuvent vous poursuivre en justice !"
+    eu: "Assurez-vous que la <strong>liberté de panorama</strong> soit appliquée à travers toute l'Europe : publier des images d'œuvres situées de manière permanente dans l'espace public doit être légal."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#panorama"
-    please: "Please ensure <strong>freedom of panorama</strong> in Europe, so that sharing photos of public buildings is legal – no matter whether for commercial or non-commercial purposes."
-    do: Reject any amendements that water down <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#panorama" target="_blank">#16</a> of MEP Reda's report, vote for the original text or the compromise amendment if there is one.
+    please: "Je vous demande de soutenir une <strong>liberté de panorama</strong> dans toute l'Europe, afin que partager des photographies de bâtiments publics soit légal – que ce soit pour un usage commercial ou non."
+    do: Rejetez tout amendement qui diluerait le point <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#panorama" target="_blank">#16</a> du rapport de la députée Julia Reda, votez en faveur du texte original ou d'un éventuel amendement de compromis.
 education: 
     h: "<span>Protect</span> educational uses"
     cw: "Schools may often freely use physical books to teach from – but putting the same content on the school intranet as a PDF can be illegal."

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -79,13 +79,13 @@ availability:
     please: "Je vous demande de soutenir une harmonisation de la <strong>durée de protection accordée par le droit d'auteur</strong> au standard défini par la convention de Berne : vie + <strong>50 ans</strong>."
     do: Rejetez les amendements au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#terms" target="_blank" class="am">#7</a> du rapport de la députée Julia Reda et supportez le point <span class="am">#18</span> de l'avis de l'<abbr title="Comission industrie, recherche et énergie">ITRE</abbr>.
 digitallocks: 
-    h: "<span>Reject</span> digital locks"
-    cw: "The law says you can make copies of media you purchased for private use – but in practice, digital locks often prevent you."
-    eu: "Ensure that technical measures can't limit your legal rights."
+    h: "<span>Rejeter</span> les verrous digitaux"
+    cw: "La loi dit qu'il est possible de faire des copies d'œuvres achetées lorsque l'usage est privé – mais en pratique, les verrous digitaux vous l'en empêchent souvent."
+    eu: "S'assurer que vos droits ne peuvent pas être limités par des mesures techniques."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#drm"
-    please: "Please ensure that technological protection (<strong>DRM</strong>) does not obstruct legal use of purchased content."
-    do: Vote for point <span class="am">#26</span> from the <abbr title="Internal Market Committee">IMCO</abbr> opinion and point <span class="am">#29</span> from the <abbr title="Industry Committee">ITRE</abbr> opinion. Support the compromise on point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#drm" target="_blank" class="am">#23</a> of MEP Reda's report and reject all amendments to point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#drm" target="_blank" class="am">#24</a>.
-    tip: "Give an example of when DRM stood in the way of your legal activity (eg. making copies for private use)."
+    please: "Je vous demande de vous assurer que les mesures techniques de protection (<strong>MTP</strong>/<strong>DRM</strong>) ne vous empêchent pas de faire un usage légal de ce que vous avez acheté."
+    do: Votez pour le point <span class="am">#26</span> de l'avis de l'<abbr title="Commission marché intérieur et protection des consommateurs">IMCO</abbr> et le point <span class="am">#29</span> de l'avis de l'<abbr title="Commission industrie, recherche et énergie">ITRE</abbr>. Je vous demande de soutenir le compromis au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#drm" target="_blank" class="am">#23</a> du rapport de la députée Julia Reda et de rejeter tous les amendements au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#drm" target="_blank" class="am">#24</a> de ce même rapport.
+    tip: "Donnez un exemple d'une situation où un DRM vous a empêché d'effectuer une action que la loi vous autorise à faire (par exemple effectuer une copie pour un usage privé)."
 filesharing: 
     h: "<span>Legalise</span> personal file sharing"
     cw: "Teenagers exchanging music online are made criminals by current laws. But frequently, a shared file is not a lost sale, but free advertising."

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -1,29 +1,29 @@
 title: Sauvez la réforme du droit d'auteur
-description: "Actuellement, l'UE est en train de débattre de propositions pour corriger des problèmes du droit d'auteur auxquels vous êtes confrontés tous les jours. Mais une puissante alliance tente de saboter ces réformes nécessaires. Allez-vous vous joindre à notre combat pour les sauver ?"
-callnow: "<span>Appelez maintenant</span> pour sauver ces réformes &ndash; ça ne prend que deux minutes !"
+description: "Actuellement, l'UE est en train de débattre de propositions pour corriger des problèmes du droit d'auteur auxquels vous êtes confrontés tous les jours. Mais une puissante alliance tente de saboter ces réformes nécessaires. Allez-vous vous joindre à notre combat pour les sauver&nbsp;?"
+callnow: "<span>Appelez maintenant</span> pour sauver ces réformes &ndash; ça ne prend que deux minutes&nbsp;!"
 savecreform: "Sauvez la<br />&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; réforme du</div>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;droit d'auteur"
 daysuntil: "jours jusqu'au vote"
 rightnow: "Actuellement,"
 debatingplans: "l'UE est en train de débattre de propositions pour corriger des problèmes du droit d'auteur auxquels vous êtes confrontés tous les jours."
 but: "Mais une puissante alliance tente de saboter ces réformes nécessaires."
-whichthree: "Quelles sont les 3 réformes les plus importantes à vos yeux ?"
+whichthree: "Quelles sont les 3 réformes les plus importantes à vos yeux&nbsp;?"
 geoblocking: 
     h: "<span>Surmonter</span> le blocage par géolocalisation"
     cw: "Cette vidéo n'est pas disponible dans votre pays."
-    eu: "<strong>Interdiction</strong> des contrats qui imposent un blocage basé sur la position géographique des utilisateurs aux services d'hébergement de vidéos : il s'agit d'une forme de discrimination des utilisateurs."
+    eu: "<strong>Interdiction</strong> des contrats qui imposent un blocage basé sur la position géographique des utilisateurs aux services d'hébergement de vidéos&nbsp;: il s'agit d'une forme de discrimination des utilisateurs."
     please: "Je vous demande de prendre position contre <strong>tout type de blocage basé sur la position géographique</strong>, indépendamment du fait que le contenu bloqué soit vendu directement ou financé au moyen de publicités ou de fonds publics."
     do: Votez pour l'amendement <abbr class="am" title="Calls for an end to geoblocking">#412</abbr> et <abbr class="am" title="States that geoblocking should not prevent cultural minorities from accessing content">#322</abbr> et le point <span class="am">#16</span> de l'avis de l'<abbr title="Commission marché intérieur et protection des consommateurs">IMCO</abbr>.
     tip: "Donnez un exemple de situation où le blocage par géolocalisation vous affecte."
 extendborders: 
     h: "<span>Étendre</span> vos droits au-delà des frontières"
-    cw: "Ce qui est autorisé varie beaucoup entre les différents pays de l'UE. Si vous ne vous renseignez pas sur les lois locales lorsque vous voyagez, vous pouvez devenir un criminel !"
+    cw: "Ce qui est autorisé varie beaucoup entre les différents pays de l'UE. Si vous ne vous renseignez pas sur les lois locales lorsque vous voyagez, vous pouvez devenir un criminel&nbsp;!"
     eu: "Rendre les <strong>exceptions et limitations</strong> au droit d'auteur <strong>obligatoire</strong> à travers tous les pays membres de l'UE."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#mandatory"
     please: "Je vous demande de prendre position en faveur de <strong>l'harmonisation des exceptions et limitations</strong> et de leur application <strong>obligatoire</strong> pour tous les pays de l'UE, afin que mes droits ne changent pas à chaque frontière."
-    do: Rejetez les amendements au point <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#terms" target="_blank">#11</a> du rapport de la députée Julia Reda. Soutenez les ajouts <abbr class="am" title="Calls for new mandatory exceptions, for example for user-generated content">#353</abbr>, <abbr class="am" title="Calls for making exceptions mandatory">#366</abbr> et le point <span class="am">#15</span> de l'avis de l'<abbr title="Marché intérieur et protection des consommateurs (Internal Market Committee)">IMCO</abbr>.
+    do: Rejetez les amendements au point <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#terms" target="_blank">#11</a> du rapport de la députée Julia Reda. Soutenez les ajouts <abbr class="am" title="Calls for new mandatory exceptions, for example for user-generated content">#353</abbr>, <abbr class="am" title="Calls for making exceptions mandatory">#366</abbr> et le point <span class="am">#15</span> de l'avis de l'<abbr title="Marché intérieur et protection des consommateurs">IMCO</abbr>.
 protectauthors: 
-    h: "<span>Protéger</span> les auteurs contre les contrats injustes"
-    cw: "Les artistes n'ont pas d'avocats. Les éditeurs et les labels en ont des légions. Devinez qui a le plus de poids lors de la négociation des contrats ?"
+    h: "<span>Protéger</span> les auteurs contre les contrats abusifs"
+    cw: "Les artistes n'ont pas d'avocats. Les éditeurs et les labels en ont des légions. Devinez qui a le plus de poids lors de la négociation des contrats&nbsp;?"
     eu: "Protéger les artistes dans toute l'Europe contre leur exploitation par des <strong>contrats abusifs</strong> et leur permettre de reprendre leur droits s'ils sont laissés à l'abandon."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#authors"
     please: "Je vous demande de prendre position pour <strong>protéger les artistes contre leur exploitation</strong> et contre l'utilisation de contrats abusifs."
@@ -38,49 +38,49 @@ righttoquote:
     tip: "Donnez un exemple de quand vous avez cité quelque chose dans une vidéo ou un fichier audio, ou si vous êtes fan de créateurs qui le font."
 righttolink: 
     h: "<span>Défendre</span> votre droit à créer des liens"
-    cw: "Le web est fait de liens. Est-ce que poster un lien est un crime ? Les éditeurs de presse demandent des lois qui limiteraient la manière dont tout un chacun pourrait faire un lien vers leur site web."
-    eu: "Rejeter ce genre de lois et préservez le droit de créer des liens."
+    cw: "Le web est fait de liens. Est-ce que poster un lien est un crime&nbsp;? Les éditeurs de presse demandent des lois qui limiteraient la manière dont tout un chacun pourrait faire un lien vers leur site web."
+    eu: "Rejeter ce genre de lois et préserver le droit de créer des liens."
     link: "https://savethelink.org"
-    please: "Je vous demande de prendre position contre un <strong>droit voisin supplémentaire pour les éditeurs de presse</strong> qui limiterait la possibilité de créer des liens vers les articles de presse."
+    please: "Je vous demande de prendre position contre une <strong>restriction supplémentaire en faveur des éditeurs de presse</strong> qui limiterait la possibilité de créer des liens vers les articles de presse."
     do: Rejetez l'amendement <abbr class="am" title="Calls for the introduction of an ancillary copyright for press publishers">#204</abbr>. Prenez position en faveur du compromis de l'amendement au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#licenses" target="_blank" class="am">#21</a> du rapport de la députée Julia Reda.
 publicdomain: 
     h: "<span>Protéger</span> le domaine public"
-    cw: "Les œuvres anciennes dont le droit d'auteur a expiré appartiennent à tout le monde. Cependant, certains prétendent que le fait de les digitaliser leur accorde un nouveau droit d'auteur."
-    eu: "La digitalisation d'œuvres appartenant à tout le monde ne doit pas accorder de nouvelles protections."
+    cw: "Les œuvres anciennes dont le droit d'auteur a expiré appartiennent à tout le monde. Cependant, certains prétendent que le fait de les numériser leur accorde un nouveau droit d'auteur."
+    eu: "La numérisation d'œuvres appartenant à tout le monde ne doit pas engendrer de nouvelles protections."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#publicdomain"
-    please: "Je vous demande de <strong>protéger le domaine public</strong> en clarifiant le fait que la digitalisation d'une œuvre libre de droits ne permet pas d'en obtenir de nouveaux."
-    do: Rejetez les amendements qui diluent le point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#publicdomain" target="_blank" class="am">#6</a> du rapport de la députée Julia Reda – prenez position en faveur de l'amendement <span class="am">#264</span> qui le clarifie.
+    please: "Je vous demande de <strong>protéger le domaine public</strong> en clarifiant le fait que la numérisation d'une œuvre libre de droits ne permet pas d'en obtenir de nouveaux."
+    do: Rejetez les amendements qui affaiblissent le point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#publicdomain" target="_blank" class="am">#6</a> du rapport de la députée Julia Reda – prenez position en faveur de l'amendement <span class="am">#264</span> qui le clarifie.
 libraries: 
     h: "<span>Permettre</span> aux librairies de faire leur travail en ligne"
-    cw: "Les librairies paient les auteurs en compensation du droit de prêter des copies physiques de leurs livres. Mais ce droit n'existe sur Internet."
+    cw: "Les librairies paient les auteurs en compensation du droit de prêter des copies physiques de leurs livres. Mais ce droit n'existe pas sur Internet."
     eu: "Permettre le <strong>prêt électronique</strong> afin que les librairies puissent remplir leur mission sociale."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#elending"
     please: "Je vous demande de prendre position en faveur de l'autorisation du <strong>prêt de livres électroniques</strong> pour les librairies."
     do: Votez pour les amendements <abbr class="am" title="Calls for expanding mandatory exceptions to cover libraries">#348</abbr>, <abbr class="am" title="Calls for strengthening exceptions in the public interest">#350</abbr> et pour les points <span class="am">#16</span> et <span class="am">#22</span> de l'avis de l'<abbr title="Commission intustrie, recherche et énergie">ITRE</abbr>.
 publicspace: 
     h: "<span>S'assurer</span> que l'espace public soit public"
-    cw: "En Allemagne, vous pouvez publier librement sur Internet des photographies de bâtiments – mais de l'autre côté de la frontière, en France, les architectes peuvent vous poursuivre en justice !"
-    eu: "S'assurer que la <strong>liberté de panorama</strong> soit appliquée à travers toute l'Europe : publier des images d'œuvres situées de manière permanente dans l'espace public doit être légal."
+    cw: "En Allemagne, vous pouvez publier librement sur Internet des photographies de bâtiments – mais de l'autre côté de la frontière, en France, les architectes peuvent vous poursuivre en justice&nbsp;!"
+    eu: "S'assurer que la <strong>liberté de panorama</strong> soit appliquée à travers toute l'Europe&nbsp;: publier des images d'œuvres situées de manière permanente dans l'espace public doit être légal."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#panorama"
     please: "Je vous demande de soutenir une <strong>liberté de panorama</strong> dans toute l'Europe, afin que partager des photographies de bâtiments publics soit légal – que ce soit pour un usage commercial ou non."
-    do: Rejetez tout amendement qui diluerait le point <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#panorama" target="_blank">#16</a> du rapport de la députée Julia Reda, votez en faveur du texte original ou d'un éventuel amendement de compromis.
+    do: Rejetez tout amendement qui affaiblirait le point <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#panorama" target="_blank">#16</a> du rapport de la députée Julia Reda, votez en faveur du texte original ou d'un éventuel amendement de compromis.
 education: 
     h: "<span>Protéger</span> les usages éducatifs"
     cw: "Les professeurs utilisent souvent librement des livres physiques pour enseigner – mais mettre le même contenu en PDF à disposition des élèves sur l'intranet de l'école peut être illégal."
-    eu: "Une exception compréhensive et pan-européenne au droit d'auteur <strong>pour les usages éducatifs</strong>."
+    eu: "Une exception complète et pan-européenne au droit d'auteur <strong>pour les usages éducatifs</strong>."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#education"
-    please: "Je vous demande de soutenir une exception au droit d'auteur qui permette les <strong>usages éducatifs</strong> d'œuvres protégées par le droit d'auteur, y-compris dans le monde digital."
-    do: Rejetez les amendements qui dilueraient le point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#education" target="_blank" class="am">#19</a> du rapport de la députée Julia Reda – c'est-à-dire tous les amendements exceptés les <span class="am">#466-468</span>.
+    please: "Je vous demande de soutenir une exception au droit d'auteur qui permette les <strong>usages éducatifs</strong> d'œuvres protégées par le droit d'auteur, y-compris dans le monde numérique."
+    do: Rejetez les amendements qui affaibliraient le point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#education" target="_blank" class="am">#19</a> du rapport de la députée Julia Reda – c'est-à-dire tous les amendements exceptés les <span class="am">#466-468</span>.
 availability: 
     h: "<span>Améliorer</span> la disponibilité des œuvres"
     cw: "Le droit d'auteur dure 70 ans après la mort de l'auteur. La grande majorité des œuvres n'est pas rentable aussi longtemps – elles deviennent simplement introuvables."
-    eu: "Réduire la durée de protection du droit d'auteur au standard international: vie de l'auteur + <strong>50 ans</strong>."
+    eu: "Réduire la durée de protection du droit d'auteur au standard international&nbsp;: vie de l'auteur + <strong>50 ans</strong>."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#term"
-    please: "Je vous demande de soutenir une harmonisation de la <strong>durée de protection accordée par le droit d'auteur</strong> au standard défini par la convention de Berne : vie + <strong>50 ans</strong>."
+    please: "Je vous demande de soutenir une harmonisation de la <strong>durée de protection accordée par le droit d'auteur</strong> au standard défini par la convention de Berne&nbsp;: vie&nbsp;+&nbsp;<strong>50&nbsp;ans</strong>."
     do: Rejetez les amendements au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#terms" target="_blank" class="am">#7</a> du rapport de la députée Julia Reda et supportez le point <span class="am">#18</span> de l'avis de l'<abbr title="Comission industrie, recherche et énergie">ITRE</abbr>.
 digitallocks: 
     h: "<span>Rejeter</span> les verrous digitaux"
-    cw: "La loi dit qu'il est possible de faire des copies d'œuvres achetées lorsque l'usage est privé – mais en pratique, les verrous digitaux vous l'en empêchent souvent."
+    cw: "La loi dit qu'il est possible de faire des copies d'œuvres achetées lorsque leur usage est privé – mais en pratique, les verrous digitaux vous l'en empêchent souvent."
     eu: "S'assurer que vos droits ne peuvent pas être limités par des mesures techniques."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#drm"
     please: "Je vous demande de vous assurer que les mesures techniques de protection (<strong>MTP</strong>/<strong>DRM</strong>) ne vous empêchent pas de faire un usage légal de ce que vous avez acheté."
@@ -92,20 +92,20 @@ filesharing:
     eu: "Reconnaître un droit au partage non-marchand."
     please: "Je vous demande d'arrêter la criminalisation du <strong>partage</strong> privé, à but non lucratif."
     do: Votez pour les amendements <abbr class="am" title="Calls for exploring the legalization of non commercial private sharing">#507</abbr> et <abbr class="am" title="Urges increased legal certainty for P2P sharing">#355</abbr>.
-    tip: "Donnez un exemple de situation où le partage a été bénéfique à un artiste, par exemple vous avez découvert un artiste êtes devenu fan, ce qui vous a amené à assister à un concert ou acheter des produits dérivés."
-currentcopywrong: "Copywrong actuel :"  # TODO: Comment traduire 'copywrong' ? Est-ce qu'il faut traduire ?
-euproposal: "Proposition de l'UE:"      # TODO: Est-ce que c'est 'de' ou 'pour' ?
-iwant: "C'est ce que je veux !"         # Maybe a bit too long... if modified, change also 'showmore'
+    tip: "Donnez un exemple de situation où le partage a été bénéfique à un artiste, par exemple vous avez découvert un artiste et êtes devenu fan, ce qui vous a amené à assister à un concert ou acheter des produits dérivés."
+currentcopywrong: "Copywrong actuel&nbsp;:"
+euproposal: "Proposition de l'UE&nbsp;:"
+iwant: "Je la veux&nbsp;!"
 readmore: "Plus d'informations"
-joinfight: Si <span>tu</span> ne rejoins la lutte maintenant, ces "copywrongs" <u>ne seront pas corrigés</u>.
+joinfight: Si <span>tu</span> ne rejoins pas la lutte maintenant, ces "copywrongs" <u>ne seront pas redressés</u>.
 call:
-    h: "Apellez maintenant pour corriger le droit d'auteur"
-    text: "Le travail des membres du Parlement Européen est de <strong>vous représenter</strong>. Nous détestons appeler les gens à froid autant que vous – mais si vous ne prenet pas <strong>2 minutes</strong> pour leur dire ce qui vous tient à cœur, seulement les lobbyistes seront entendus. Vous pouvez le faire, et <u>chaque appel a un véritable impact !</u>"
+    h: "Apellez maintenant pour réparer le droit d'auteur"
+    text: "Le travail des membres du Parlement Européen est de <strong>vous représenter</strong>. Nous détestons appeler les gens à froid autant que vous – mais si vous ne prenez pas <strong>2 minutes</strong> pour leur dire ce qui vous tient à cœur, les lobbyistes seront les seuls entendus. Vous pouvez le faire, et <u>chaque appel a un véritable impact&nbsp;!</u>"
     showother: "Montrer un autre député"
-    what: "Comment se passera l'appel ? (EN)" # FIXME: Le lien pointe sur la page en anglais, il ne semble pas possible de le modifier ici (une version en français est disponible)
-    agenda: "Votre agenda personnel :"
+    what: "Comment se passera l'appel&nbsp;? (EN)" # FIXME: Le lien pointe sur la page en anglais, il ne semble pas possible de le modifier ici (une version en français est disponible)
+    agenda: "Votre agenda personnel&nbsp;:"
     agendatext: "En ce qui concerne le <strong>rapport sur le droit d'auteur</strong> sur lequel vous allez voter en Commission des Affaires Juridiques le 16 juin..."
-showmore: Pour afficher plus de points ici, faites défiler la page vers le haut et cliquer sur "c'est ce que je veux"
+showmore: Pour afficher plus de points ici, faites défiler la page vers le haut et cliquer sur "je la veux"
 tell: Partagez
 icalled: J'ai appelé mon député pour sauver la réforme du droit d'auteur<br />– et toi?
 sharetext:  La réforme urgente du droit d'auteur est en danger. J'ai appelé mon député, et tu devrais aussi!

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -17,14 +17,14 @@ geoblocking:
 extendborders: 
     h: "<span>Étendre</span> vos droits au-delà des frontières"
     cw: "Ce qui est autorisé varie beaucoup entre les différents pays de l'UE. Si vous ne vous renseignez pas sur les lois locales lorsque vous voyagez, vous pouvez devenir un criminel !"
-    eu: "Rendez les <strong>exceptions et limitations</strong> au droit d'auteur <strong>obligatoire</strong> à travers tous les pays membres de l'UE."
+    eu: "Rendre les <strong>exceptions et limitations</strong> au droit d'auteur <strong>obligatoire</strong> à travers tous les pays membres de l'UE."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#mandatory"
     please: "Je vous demande de prendre position en faveur de <strong>l'harmonisation des exceptions et limitations</strong> et de leur application <strong>obligatoire</strong> pour tous les pays de l'UE, afin que mes droits ne changent pas à chaque frontière."
     do: Rejetez les amendements au point <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#terms" target="_blank">#11</a> du rapport de la députée Julia Reda. Soutenez les ajouts <abbr class="am" title="Calls for new mandatory exceptions, for example for user-generated content">#353</abbr>, <abbr class="am" title="Calls for making exceptions mandatory">#366</abbr> et le point <span class="am">#15</span> de l'avis de l'<abbr title="Marché intérieur et protection des consommateurs (Internal Market Committee)">IMCO</abbr>.
 protectauthors: 
     h: "<span>Protéger</span> les auteurs contre les contrats injustes"
     cw: "Les artistes n'ont pas d'avocats. Les éditeurs et les labels en ont des légions. Devinez qui a le plus de poids lors de la négociation des contrats ?"
-    eu: "Protégez les artistes dans toute l'Europe contre leur exploitation par des <strong>contrats abusifs</strong> et permettez-leur de reprendre leur droits s'ils sont laissés à l'abandon."
+    eu: "Protéger les artistes dans toute l'Europe contre leur exploitation par des <strong>contrats abusifs</strong> et leur permettre de reprendre leur droits s'ils sont laissés à l'abandon."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#authors"
     please: "Je vous demande de prendre position pour <strong>protéger les artistes contre leur exploitation</strong> et contre l'utilisation de contrats abusifs."
     do: Votez pour l'amendement de compromis sur le point <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#authors" target="_blank">#3</a> du rapport de la députée Julia Reda et soutenez les ajouts des amendements <abbr class="am" title="Cites a UN report that emphasizes the importance of protecting authors">#107</abbr>, <abbr class="am" title="Calls for an author's right to bring their works to the market themselves in case a rightholder does not do so for a period of time">#200</abbr> et <abbr class="am" title="Calls for income tied to exceptions and limitations (e.g. private copying levies) to go directly to the authors, not other rightholders">#527</abbr>.
@@ -39,7 +39,7 @@ righttoquote:
 righttolink: 
     h: "<span>Défendre</span> votre droit à créer des liens"
     cw: "Le web est fait de liens. Est-ce que poster un lien est un crime ? Les éditeurs de presse demandent des lois qui limiteraient la manière dont tout un chacun pourrait faire un lien vers leur site web."
-    eu: "Rejetez ce genre de lois et préservez le droit de créer des liens."
+    eu: "Rejeter ce genre de lois et préservez le droit de créer des liens."
     link: "https://savethelink.org"
     please: "Je vous demande de prendre position contre un <strong>droit voisin supplémentaire pour les éditeurs de presse</strong> qui limiterait la possibilité de créer des liens vers les articles de presse."
     do: Rejetez l'amendement <abbr class="am" title="Calls for the introduction of an ancillary copyright for press publishers">#204</abbr>. Prenez position en faveur du compromis de l'amendement au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#licenses" target="_blank" class="am">#21</a> du rapport de la députée Julia Reda.
@@ -53,14 +53,14 @@ publicdomain:
 libraries: 
     h: "<span>Permettre</span> aux librairies de faire leur travail en ligne"
     cw: "Les librairies paient les auteurs en compensation du droit de prêter des copies physiques de leurs livres. Mais ce droit n'existe sur Internet."
-    eu: "Permettez le <strong>prêt électronique</strong> afin que les librairies puissent remplir leur mission sociale."
+    eu: "Permettre le <strong>prêt électronique</strong> afin que les librairies puissent remplir leur mission sociale."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#elending"
     please: "Je vous demande de prendre position en faveur de l'autorisation du <strong>prêt de livres électroniques</strong> pour les librairies."
     do: Votez pour les amendements <abbr class="am" title="Calls for expanding mandatory exceptions to cover libraries">#348</abbr>, <abbr class="am" title="Calls for strengthening exceptions in the public interest">#350</abbr> et pour les points <span class="am">#16</span> et <span class="am">#22</span> de l'avis de l'<abbr title="Commission intustrie, recherche et énergie">ITRE</abbr>.
 publicspace: 
     h: "<span>S'assurer</span> que l'espace public soit public"
     cw: "En Allemagne, vous pouvez publier librement sur Internet des photographies de bâtiments – mais de l'autre côté de la frontière, en France, les architectes peuvent vous poursuivre en justice !"
-    eu: "Assurez-vous que la <strong>liberté de panorama</strong> soit appliquée à travers toute l'Europe : publier des images d'œuvres situées de manière permanente dans l'espace public doit être légal."
+    eu: "S'assurer que la <strong>liberté de panorama</strong> soit appliquée à travers toute l'Europe : publier des images d'œuvres situées de manière permanente dans l'espace public doit être légal."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#panorama"
     please: "Je vous demande de soutenir une <strong>liberté de panorama</strong> dans toute l'Europe, afin que partager des photographies de bâtiments publics soit légal – que ce soit pour un usage commercial ou non."
     do: Rejetez tout amendement qui diluerait le point <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#panorama" target="_blank">#16</a> du rapport de la députée Julia Reda, votez en faveur du texte original ou d'un éventuel amendement de compromis.
@@ -74,7 +74,7 @@ education:
 availability: 
     h: "<span>Améliorer</span> la disponibilité des œuvres"
     cw: "Le droit d'auteur dure 70 ans après la mort de l'auteur. La grande majorité des œuvres n'est pas rentable aussi longtemps – elles deviennent simplement introuvables."
-    eu: "Réduisez la durée de protection du droit d'auteur au standard international: vie de l'auteur + <strong>50 ans</strong>."
+    eu: "Réduire la durée de protection du droit d'auteur au standard international: vie de l'auteur + <strong>50 ans</strong>."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#term"
     please: "Je vous demande de soutenir une harmonisation de la <strong>durée de protection accordée par le droit d'auteur</strong> au standard défini par la convention de Berne : vie + <strong>50 ans</strong>."
     do: Rejetez les amendements au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#terms" target="_blank" class="am">#7</a> du rapport de la députée Julia Reda et supportez le point <span class="am">#18</span> de l'avis de l'<abbr title="Comission industrie, recherche et énergie">ITRE</abbr>.

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -37,12 +37,12 @@ righttoquote:
     do: Rejetez les amendements au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#audiovisual" target="_blank" class="am">#14</a> du rapport de la députée Julia Reda.
     tip: "Donnez un exemple de quand vous avez cité quelque chose dans une vidéo ou un fichier audio, ou si vous êtes fan de créateurs qui le font."
 righttolink: 
-    h: "<span>Defend</span> your right to link"
-    cw: "The web is made of links. Can posting one be a crime? News publishers are calling for laws that limit how others can link to their websites."
-    eu: "Reject such laws and preserve the freedom to link."
+    h: "<span>Défendre</span> votre droit à créer des liens"
+    cw: "Le web est fait de liens. Est-ce que poster un lien est un crime ? Les éditeurs de presse demandent des lois qui limiteraient la manière dont tout un chacun pourrait faire un lien vers leur site web."
+    eu: "Rejetez ce genre de lois et préservez le droit de créer des liens."
     link: "https://savethelink.org"
-    please: "Please take a stand against an <strong>ancillary copyright for press publishers</strong> which would restrict linking to news articles."
-    do: Reject amendment <abbr class="am" title="Calls for the introduction of an ancillary copyright for press publishers">#204</abbr>. Support the compromise amendment on point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#licenses" target="_blank" class="am">#21</a> of MEP Reda's report.
+    please: "Je vous demande de prendre position contre un <strong>droit voisin supplémentaire pour les éditeurs de presse</strong> qui limiterait la possibilité de créer des liens vers les articles de presse."
+    do: Rejetez l'amendement <abbr class="am" title="Calls for the introduction of an ancillary copyright for press publishers">#204</abbr>. Prenez position en faveur du compromis de l'amendement au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#licenses" target="_blank" class="am">#21</a> du rapport de la députée Julia Reda.
 publicdomain: 
     h: "<span>Safeguard</span> the public domain"
     cw: "Old artwork whose copyright has expired belongs to everyone. Yet some people claim digitising it grants new copyright."

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -92,21 +92,21 @@ filesharing:
     eu: "Reconnaître un droit au partage non-marchand."
     please: "Je vous demande d'arrêter la criminalisation du <strong>partage</strong> privé, à but non lucratif."
     do: Votez pour les amendements <abbr class="am" title="Calls for exploring the legalization of non commercial private sharing">#507</abbr> et <abbr class="am" title="Urges increased legal certainty for P2P sharing">#355</abbr>.
-    tip: "Donner un exemple de situation où le partage a été bénéfique à un artiste, par exemple vous avez découvert un artiste êtes devenu fan, ce qui vous a amené à assister à un concert ou acheter des produits dérivés."
-currentcopywrong: "Current copywrong:"
-euproposal: "EU proposal:"
-iwant: "I want this!"
-readmore: "Read more"
-joinfight: If <span>you</span> don't join the fight now, these "copywrongs" <u>won't be fixed</u>.
+    tip: "Donnez un exemple de situation où le partage a été bénéfique à un artiste, par exemple vous avez découvert un artiste êtes devenu fan, ce qui vous a amené à assister à un concert ou acheter des produits dérivés."
+currentcopywrong: "Copywrong actuel :"  # TODO: Comment traduire 'copywrong' ? Est-ce qu'il faut traduire ?
+euproposal: "Proposition de l'EU:"      # TODO: Est-ce que c'est 'de' ou 'pour' ?
+iwant: "C'est ce que je veux !"         # Maybe a bit too long... if modified, change also 'showmore'
+readmore: "Plus d'informations"
+joinfight: Si <span>tu</span> ne rejoins la lutte maintenant, ces "copywrongs" <u>ne seront pas corrigés</u>.
 call:
-    h: "Call now to fix copyright"
-    text: "The job of Members of the European Parliament is to <strong>represent you</strong>. We hate cold-calling people as much as you do &ndash; but if you don't take <strong>2 minutes</strong> to tell them what you care about, <strong>only lobbyists will be heard</strong>. You can do it, and <u>every call really makes a difference!</u>"
-    showother: "Show me another MEP"
-    what: "What will the call be like?"
-    agenda: "Your personal agenda:"
-    agendatext: "Regarding the <strong>copyright report</strong> that you will vote on in the Legal Affairs Committee on June 16th..."
-showmore: To show more points here, scroll up and click "I want this"
-tell: Tell the world
-icalled: I called my MEP to save copyright reform<br />– will you, too?
-sharetext:  Urgently needed copyright reform plans are in danger. I called my MEP and you should, too!
-credits: Created by the office of <a href="https://juliareda.eu" target="_blank">MEP Julia Reda</a>, the team of <a href="http://copy-me.org/" target="_blank">Copy-Me</a> and additional volunteers. <a href="https://github.com/Copywrongs-Gang/Copywrongs2">Fork me on Github</a><br />Graphics based in part on icons by EliRatus, useiconic.com, Cornelius Danger, Pedro Vidal, John Caserta, Carolina Andrea, Magicon, Luis Prado – all licensed Creative Commons – Attribution (CC BY 3.0)
+    h: "Apellez maintenant pour corriger le droit d'auteur"
+    text: "Le travail des membres du Parlement Européen est de <strong>vous représenter</strong>. Nous détestons appeler les gens à froid autant que vous – mais si vous ne prenet pas <strong>2 minutes</strong> pour leur dire ce qui vous tient à cœur, seulement les lobbyistes seront entendus. Vous pouvez le faire, et <u>chaque appel a un véritable impact !</u>"
+    showother: "Montrer un autre député"
+    what: "Comment se passera l'appel ? (EN)" # FIXME: Le lien pointe sur la page en anglais, il ne semble pas possible de le modifier ici (une version en français est disponible)
+    agenda: "Votre agenda personnel :"
+    agendatext: "En ce qui concerne le <strong>rapport sur le droit d'auteur</strong> sur lequel vous allez voter en Commission des Affaires Juridiques le 16 juin..."
+showmore: Pour afficher plus de points ici, faites défiler la page vers le haut et cliquer sur "c'est ce que je veux"
+tell: Partagez
+icalled: J'ai appelé mon député pour sauver la réforme du droit d'auteur<br />– et toi?
+sharetext:  La réforme urgente du droit d'auteur est en danger. J'ai appelé mon député, et tu devrais aussi!
+credits: Créé par le bureau de la <a href="https://juliareda.eu" target="_blank">députée Julia Reda</a>, l'équipe de <a href="http://copy-me.org/" target="_blank">Copy-Me</a> et d'autes volontaires. <a href="https://github.com/Copywrongs-Gang/Copywrongs2">Fork me on Github</a><br />Charte graphique basée en partie sur des icônes créées par EliRatus, useiconic.com, Cornelius Danger, Pedro Vidal, John Caserta, Carolina Andrea, Magicon, Luis Prado – all licensed Creative Commons – Attribution (CC BY 3.0)

--- a/_data/french.yml
+++ b/_data/french.yml
@@ -29,13 +29,13 @@ protectauthors:
     please: "Je vous demande de prendre position pour <strong>protéger les artistes contre leur exploitation</strong> et contre l'utilisation de contrats abusifs."
     do: Votez pour l'amendement de compromis sur le point <a class="am" href="https://juliareda.eu/copyright-evaluation-report-explained/#authors" target="_blank">#3</a> du rapport de la députée Julia Reda et soutenez les ajouts des amendements <abbr class="am" title="Cites a UN report that emphasizes the importance of protecting authors">#107</abbr>, <abbr class="am" title="Calls for an author's right to bring their works to the market themselves in case a rightholder does not do so for a period of time">#200</abbr> et <abbr class="am" title="Calls for income tied to exceptions and limitations (e.g. private copying levies) to go directly to the authors, not other rightholders">#527</abbr>.
 righttoquote: 
-    h: "<span>Grant</span> vloggers the right to quote"
-    cw: "Quoting some words is usually legal, but this hasn't been extended to videos or sound recordings – making YouTubers & podcasters outlaws."
-    eu: "Exceptions like the one for quotation must apply to all forms of cultural expression in a <strong>technology-neutral</strong> manner."
+    h: "<span>Donner</span> aux vloggers le droit de citation"
+    cw: "Citer quelques mots est généralement légal, mais ce droit n'a pas été étendu aux enregistrements vidéos ou sonores ­– les YouTubers et podcasters sont de ce fait des criminels."
+    eu: "Les exceptions au droit d'auteur telles que celle permettant la citation doivent s'appliquer à toutes formes d'expression culturelle et de manière <strong>technologiquement neutre</strong>."
     link: "https://juliareda.eu/copyright-evaluation-report-explained/#audiovisual"
-    please: "Please support <strong>extending quotation rights to audiovisual media</strong>."
-    do: Reject the amendments to point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#audiovisual" target="_blank" class="am">#14</a> of MEP Reda's report.
-    tip: "Give an example of when you've quoted something in video or audio or if you're a fan of creators who do."
+    please: "Je vous demande de prendre position en faveur de <strong>l'extension du droit de citation aux médias audiovisuels</strong>."
+    do: Rejetez les amendements au point <a href="https://juliareda.eu/copyright-evaluation-report-explained/#audiovisual" target="_blank" class="am">#14</a> du rapport de la députée Julia Reda.
+    tip: "Donnez un exemple de quand vous avez cité quelque chose dans une vidéo ou un fichier audio, ou si vous êtes fan de créateurs qui le font."
 righttolink: 
     h: "<span>Defend</span> your right to link"
     cw: "The web is made of links. Can posting one be a crime? News publishers are calling for laws that limit how others can link to their websites."

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,15 +33,15 @@
 
 		<div id="lang"><div class="cont">
 			<select id="lang" onchange="document.location.replace('/'+this.options[this.selectedIndex].value)">
-		        <!--option value="cz"{% if page.language == "cz" %} selected{% endif %}>CZ - Čeština</option-->
+		        <!-- <option value="cz"{% if page.language == "cz" %} selected{% endif %}>CZ - Čeština</option> -->
 		        <option value="de"{% if page.language == "german" %} selected{% endif %}>DE - Deutsch</option>
-		        <!--option value="el"{% if page.language == "el" %} selected{% endif %}>EL - Ελληνικά</option-->
+		        <!-- <option value="el"{% if page.language == "el" %} selected{% endif %}>EL - Ελληνικά</option> -->
 		        <option value="" {% if page.language == "english" %} selected{% endif %}>EN - English</option>
-		        <!--option value="es"{% if page.language == "es" %} selected{% endif %}>ES - Español</option>
-		        <option value="fr"{% if page.language == "fr" %} selected{% endif %}>FR - Français</option>
-		        <option value="it"{% if page.language == "it" %} selected{% endif %}>IT - Italiano</option>
-		        <option value="pl"{% if page.language == "pl" %} selected{% endif %}>PL - Polski</option>
-		        <option value="ro"{% if page.language == "ro" %} selected{% endif %}>RO - Română</option-->
+		        <!-- <option value="es"{% if page.language == "es" %} selected{% endif %}>ES - Español</option> -->
+		        <option value="fr"{% if page.language == "french" %} selected{% endif %}>FR - Français</option>
+		        <!-- <option value="it"{% if page.language == "it" %} selected{% endif %}>IT - Italiano</option> -->
+		        <!-- <option value="pl"{% if page.language == "pl" %} selected{% endif %}>PL - Polski</option> -->
+		        <!-- <option value="ro"{% if page.language == "ro" %} selected{% endif %}>RO - Română</option> -->
 	    	</select>
 	    </div></div>
 


### PR DESCRIPTION
I am a native French speaker and based the translation on the English version.
It would not hurt to have someone proofread the translation before putting it in production (I am not a professional translator; "this translation is provided as-is" etc.) and check for overall consistency.

I chose to translate "copyright" as "droit d'auteur", which are slightly different concepts, as most European countries (especially all French speaking ones) uses the latter, not the former.
I was not able to translate "copywrong" while keeping the play on words, so I left it as is.

The link to the LQDN wiki (How to contact a MEP) is pointing to the English version, even if a French version is available. The link could not be modified from the translation file, which you might want to fix.
